### PR TITLE
Disables default scrolling behavior for any keys used to control the game

### DIFF
--- a/src/Game.js
+++ b/src/Game.js
@@ -186,6 +186,20 @@ export class Game {
                 platformController.getBottomPlatform().next.relativePosition
             ]
         );
+
+        // Disables scrolling behavior for keys used to control game
+        window.addEventListener(
+            'keydown',
+            (e) => {
+                if (
+                    e.code === 'Space' ||
+                    e.code === 'ArrowUp' ||
+                    e.code === 'ArrowDown'
+                )
+                    e.preventDefault();
+            },
+            false
+        );
     }
 
     getContext() {


### PR DESCRIPTION
To test, press:
- space
- up arrow
- down arrow

The browser window should stay in place and should not scroll.